### PR TITLE
Cleaned up Comments and Info section

### DIFF
--- a/bootstrapTheme/static/rhombik/css/global.scss
+++ b/bootstrapTheme/static/rhombik/css/global.scss
@@ -10,7 +10,33 @@ body {background-color:$backround-color;}
     position: relative;
     top: -10px;
     padding: 25px;
+    border-style: solid; /* There should be no border between the active tab and the infobox, need to fix */
+    border-width: 1px;
+    border-color: #dddddd; 
 }
+
+.#TextsMain a:link {
+    font-weight: bold;
+    color: #66357F;
+}
+
+.TextsMain a:visited {
+    font-weight: bold;
+    color: #800080;
+}
+
+/*This highlights all links, including the profile and reply one.
+Once the comments section is cleaned up a bit more we should fix that */
+.comments a:link {
+    font-weight: bold;
+    color: #66357F;
+}
+
+.comments a:visited {
+    font-weight: bold;
+    color: #800080;
+}
+
 .fullwidth{
     display: block; 
     width: 100%;


### PR DESCRIPTION
Links posted in the Comments or the Readme.md section of download pages now are bolded and a color (#66357F) between the top bar's color and blue, and purple (#800800) when already visited.

Also fixed the border to Readme.md, the tab had one but the actual information box was missing one. Need to find a way to get rid of the border between readme.md and the box.
